### PR TITLE
feat: compute execution time and then analyze them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ __pycache__
 *.zip
 gui.py
 
+# dataset
+*.tar.gz
+
 # log
 logs/*
 config.*

--- a/LOG.md
+++ b/LOG.md
@@ -21,6 +21,14 @@
 
 ## Version 7
 
+### 11/17 - fan
+
+- feat: compute execution time and then analyze them.
+	- `new`: In `demo_utils.py`: add `timer` function to compute execution time
+		- add `--timer` argument to activate timer
+	- `new`: In `demo.py`: now can analyze the execution time with `--timer`
+	- `doc`: In `.gitignore`: add `*.tar.gz` avoid to push dataset to github
+
 ### 11/17 - jefflin
 - Improve the demo process
     - `new`: In `demo/demo_utils.py`: 

--- a/demo/demo_utils.py
+++ b/demo/demo_utils.py
@@ -1,5 +1,6 @@
 import sys
 sys.path.append('..')
+import time
 
 from argparse import ArgumentParser
 from utils import StorePair
@@ -99,4 +100,26 @@ def argument_setting():
     parser.add_argument('--criterion', type=str, default='huber',
                         help="set criterion (default: 'huber')")
 
+    # timer setting
+    parser.add_argument('--timer', default=False, action='store_true',
+                        help='compute execution time function by function (default: False)')
+
     return parser.parse_args()
+
+
+def timer(func):
+    def wrapper(*args, **kwargs):
+        
+        print(f'evaluate "{func.__name__}" execution time')
+        start = time.time()
+
+        func(*args, **kwargs)
+
+        end = time.time()
+        print(f'"{func.__name__}" execution time: {end - start:.2f}')
+        
+        # return execution time
+        return end - start
+
+    return wrapper
+        

--- a/eval.py
+++ b/eval.py
@@ -89,6 +89,7 @@ def test(model, test_loader, criterion, args):
         model_path = os.path.join(log_path, f'{args.model_name}_{args.scale}x.pt')
 
     # load model parameters
+    # print(model_path)
     checkpoint = torch.load(model_path, map_location=f'cuda:{args.gpu_id}')
 
     # try-except to compatible


### PR DESCRIPTION
modified: demo/(demo_utils.py, demo.py) .gitignore
`new`: In `demo_utils.py`: add `timer` function to compute execution time
	add `--timer` argument to activate timer
`new`: In `demo.py`: now can analyze the execution time with `--timer`
`doc`: In `.gitignore`: add `*.tar.gz` avoid to push dataset to github