### PR TITLE
fix out2csv bug

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -41,6 +41,10 @@
     - `update`: In `postprocessor.py`, `post_utils.py` and `README.md` in `postprocessing/`:
         - add `demo_post` argument to switch to demo post-processing
 
+- fix out2csv bug
+    - `fixed`: In `out2csv` in `utils.py`:
+        - fix np.squeeze bugs when the shape of output is [1, 1, 150, 6]
+
 ### 11/16 - jefflin
 - Solve demo bugs
   

--- a/utils.py
+++ b/utils.py
@@ -562,7 +562,7 @@ def out2csv(inputs, epoch, file_string, out_num, save_path, stroke_length, spec_
     if not os.path.exists(save_path):
         os.mkdir(save_path)
 
-    output = np.squeeze(inputs.cpu().detach().numpy())
+    output = np.squeeze(inputs.cpu().detach().numpy(), axis=1)
 
     if spec_flag == False:
         table = output[0:out_num]


### PR DESCRIPTION
- `fixed`: In `out2csv` in `utils.py`:
	- fix np.squeeze bugs when the shape of output is [1, 1, 150, 6]